### PR TITLE
Release v1.3.0 (for real this time)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.1] - 2019-06-23
+## [1.3.0] / 2019.06.23
+### Added
+- Caching via [go-cache](https://github.com/patrickmn/go-cache)
+- ClearCache function (to clear existing cache)
+  
+## [1.2.1] / 2019.06.23
 ### Changed
 - Added additional unit tests for Search.
 
-## [1.2.0] - 2019-06-22
+## [1.2.0] / 2019.06.22
 ### Added
 - Search function for filtering resource lists
   - Ability to filter by any string
   - Ability to filter by "starts with" using ^
 
-## [1.1.1] - 2019-06-22
+## [1.1.1] / 2019.06.22
 ### Added
 - Coverage via Codecov
 - Badges for GoReport, GoDoc, license
 
-## [1.1.0] - 2019-06-22
+## [1.1.0] / 2019.06.22
 ### Added
 - Optional parameters for Resource calls:
   - Offset (defaults to zero)
   - Limit (defaults to twenty, per API)
 
-## [1.0.0] - 2019-06-22
+## [1.0.0] / 2019.06.22
 ### Added
 - Endpoint Categories
   - Berries (berries, firmness, flavors)
@@ -41,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resource endpoint for resource lists
 - Unit tests for all endpoints
 
-[Unreleased]: https://github.com/mtslzr/pokeapi-go/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/mtslzr/pokeapi-go/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/mtslzr/pokeapi-go/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/mtslzr/pokeapi-go/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/mtslzr/pokeapi-go/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/mtslzr/pokeapi-go/compare/v1.1.0...v1.1.1

--- a/tests/items_test.go
+++ b/tests/items_test.go
@@ -56,7 +56,7 @@ func TestItemCategoryByName(t *testing.T) {
 }
 
 func TestItemCategoryFail(t *testing.T) {
-	result, _ := pokeapi.Item("asdf")
+	result, _ := pokeapi.ItemCategory("asdf")
 	assert.Equal(t, "", result.Name,
 		"Expect to receive an empty result.")
 }


### PR DESCRIPTION
Fixed CHANGELOG, and added in a corrected test function name. Finally good to go.